### PR TITLE
Updated action runner_type to python-script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 0.3.0
+
+- Updated action `runner_type` from `run-python` to `python-script`
+
 # 0.2.0
 
 - Rename `config.yaml` to `config.schema.yaml` and update to use schema.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ Configuration options:
 You can also use dynamic values from the datastore. See the
 [docs](https://docs.stackstorm.com/reference/pack_configs.html) for more info.
 
+**Note** : When modifying the configuration in `/opt/stackstorm/configs/` please
+           remember to tell StackStorm to load these new values by running
+           `st2ctl reload --register-configs`
+
 ## Actions
 
 * ``list_keys`` - List all the keys in the keyring.

--- a/actions/decrypt_file.yaml
+++ b/actions/decrypt_file.yaml
@@ -1,6 +1,6 @@
 ---
   name: "decrypt_file"
-  runner_type: "run-python"
+  runner_type: "python-script"
   description: "Decrypt asymmetrically encrypted GPG file."
   enabled: true
   entry_point: "decrypt_file.py"

--- a/actions/encrypt_file.yaml
+++ b/actions/encrypt_file.yaml
@@ -1,6 +1,6 @@
 ---
   name: "encrypt_file"
-  runner_type: "run-python"
+  runner_type: "python-script"
   description: "Encrypt a file using asymmetric encryption for the provided recipients."
   enabled: true
   entry_point: "encrypt_file.py"

--- a/actions/import_keys.yaml
+++ b/actions/import_keys.yaml
@@ -1,6 +1,6 @@
 ---
   name: "import_keys"
-  runner_type: "run-python"
+  runner_type: "python-script"
   description: "Import keys into the keyring."
   enabled: true
   entry_point: "import_keys.py"

--- a/actions/list_keys.yaml
+++ b/actions/list_keys.yaml
@@ -1,6 +1,6 @@
 ---
   name: "list_keys"
-  runner_type: "run-python"
+  runner_type: "python-script"
   description: "List all keys in the keyring."
   enabled: true
   entry_point: "list_keys.py"

--- a/pack.yaml
+++ b/pack.yaml
@@ -9,6 +9,6 @@ keywords:
   - privacy
   - encryption
   - crypto
-version : 0.2.0
+version : 0.3.0
 author : StackStorm, Inc.
 email : info@stackstorm.com


### PR DESCRIPTION
Updated action `runner_type` from `run-python` to `python-script` based on the following issue: https://github.com/StackStorm/st2/issues/3389 .

Also, updated README.md with a note on running `st2ctl reload --register-configs` when performing config modifications.